### PR TITLE
Fix multiple-select dropdown to remain open after selection

### DIFF
--- a/components/ui/multiple-select.tsx
+++ b/components/ui/multiple-select.tsx
@@ -242,6 +242,7 @@ const MultipleSelect = <T extends SelectedKey>({
             inputValue={fieldState.inputValue}
             onSelectionChange={onSelectionChange}
             onInputChange={onInputChange}
+            shouldCloseOnBlur={false}
           >
             <div className={comboBoxChild({ className })}>
               <Input
@@ -275,6 +276,7 @@ const MultipleSelect = <T extends SelectedKey>({
               style={{ width: `${width}px` }}
               triggerRef={triggerRef}
               trigger="ComboBox"
+              shouldCloseOnBlur={false}
             >
               <ListBox.Picker
                 renderEmptyState={() =>


### PR DESCRIPTION
Related to #214

Update `MultipleSelect` component to keep the dropdown open after selection.

* Add `shouldCloseOnBlur={false}` to `Popover.Picker` to prevent closing on blur.
* Modify `onSelectionChange` function to keep the dropdown open after setting the selected key and input value.
