### PR TITLE
fix(stars-badge): resolve dark mode hover issue

### DIFF
--- a/app/(app)/partials/hero.tsx
+++ b/app/(app)/partials/hero.tsx
@@ -54,7 +54,7 @@ export function Hero() {
                 appearance: "outline",
                 shape: "circle",
                 className:
-                  "group bg-white text-zinc-900 hover:bg-zinc-100 **:data-[slot=icon]:text-warning",
+                  "group bg-white text-zinc-900 hover:bg-zinc-100 dark:hover:text-white **:data-[slot=icon]:text-warning",
               })}
             >
               <IconStar className="group-hover:text-yellow-500 group-hover:fill-yellow-500" /> Stars


### PR DESCRIPTION
This pull request fixes the Stars Badge hover state issue in dark mode, ensuring proper visibility and contrast.

### Before
<img width="179" alt="Screenshot 2024-12-21 at 06 02 07" src="https://github.com/user-attachments/assets/0a9bdc93-2b23-47f5-831f-eb9882f5f451" />

### After
<img width="178" alt="Screenshot 2024-12-21 at 06 10 25" src="https://github.com/user-attachments/assets/4f3d867f-9c51-4d29-91b5-bfea853972e8" />
