### PR TITLE
fix: Toolbar Popover Weird Padding

### DIFF
--- a/components/blocks/slider-on-popover-block.tsx
+++ b/components/blocks/slider-on-popover-block.tsx
@@ -28,6 +28,7 @@ export function SliderOnPopoverBlock() {
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         showArrow={false}
+        className="p-4"
       >
         <div className="space-y-4">
           <Slider


### PR DESCRIPTION
### Before / After

<div style="display: flex;">
<img src="https://github.com/user-attachments/assets/6701e8a0-4363-4dd8-b99f-b4646fd0af18" alt="Before" style="width: 45%;"/>
<img src="https://github.com/user-attachments/assets/c3f38ba1-2643-48a9-b954-a2891f67c2b7" alt="After" style="width: 45%;"/>

</div>