### PR TITLE
Fix: Toolbar Popover Weird y Padding

### DIFF
--- a/components/blocks/slider-on-popover-block.tsx
+++ b/components/blocks/slider-on-popover-block.tsx
@@ -1,16 +1,16 @@
-"use client"
+"use client";
 
-import { useRef, useState } from "react"
+import { useRef, useState } from "react";
 
-import { IconAdjustment } from "justd-icons"
-import { Button, Description, Popover, Separator, Slider } from "ui"
+import { IconAdjustment } from "justd-icons";
+import { Button, Description, Popover, Separator, Slider } from "ui";
 
 export function SliderOnPopoverBlock() {
-  const [fontSize, setFontSize] = useState<number>(16)
-  const [lineHeight, setLineHeight] = useState<number>(42)
+  const [fontSize, setFontSize] = useState<number>(16);
+  const [lineHeight, setLineHeight] = useState<number>(42);
 
-  const [isOpen, setIsOpen] = useState(false)
-  const button = useRef(null)
+  const [isOpen, setIsOpen] = useState(false);
+  const button = useRef(null);
 
   return (
     <>
@@ -28,8 +28,9 @@ export function SliderOnPopoverBlock() {
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         showArrow={false}
+        className="py-4"
       >
-        <Popover.Body className="space-y-4 py-4">
+        <Popover.Body className="space-y-4">
           <Slider
             output="tooltip"
             value={fontSize}
@@ -49,5 +50,5 @@ export function SliderOnPopoverBlock() {
         </Popover.Body>
       </Popover.Content>
     </>
-  )
+  );
 }


### PR DESCRIPTION
### Before / After
Tested on: Arc (Windows 11)

<div style="display: flex;">
<img src="https://github.com/user-attachments/assets/d88cdfa0-032a-4b44-813f-b4eb9ea034da" alt="Before" style="width: 45%;"/>

<img src="https://github.com/user-attachments/assets/1c20234d-15fc-45b2-b6e1-87960befda05" alt="After" style="width: 45%;"/>

</div>