### PR TITLE
No children needed. Make Typescript happy.

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -154,7 +154,7 @@ const Close = ({ className, appearance = "outline", ref, ...props }: ButtonProps
   return <Button slot="close" className={className} ref={ref} appearance={appearance} {...props} />
 }
 
-interface CloseButtonIndicatorProps extends ButtonProps {
+interface CloseButtonIndicatorProps extends Omit<ButtonProps, 'children'> {
   className?: string
   isDismissable?: boolean | undefined
 }


### PR DESCRIPTION
Otherwise TypeScript complains about the usage in <Modal>