### PR TITLE
Avoid jump in modal animation (again)

### DIFF
--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -18,7 +18,7 @@ const Modal = (props: DialogTriggerProps) => {
 const modalOverlayStyles = tv({
   base: [
     "fixed top-0 left-0 isolate z-50 h-(--visual-viewport-height) w-full",
-    "flex items-end justify-end bg-fg/15 text-center sm:items-center sm:justify-center dark:bg-bg/40",
+    "flex items-end justify-end bg-fg/15 text-center sm:block dark:bg-bg/40",
     "[--visual-viewport-vertical-padding:16px] sm:[--visual-viewport-vertical-padding:32px]",
   ],
   variants: {
@@ -37,6 +37,7 @@ const modalContentStyles = tv({
   base: [
     "max-h-full w-full rounded-t-2xl bg-overlay text-left align-middle text-overlay-fg shadow-lg ring-1 ring-fg/5",
     "overflow-hidden sm:rounded-2xl dark:ring-border",
+    "sm:fixed sm:top-1/2 sm:left-[50vw] sm:-translate-x-1/2 sm:-translate-y-1/2",
   ],
   variants: {
     isEntering: {


### PR DESCRIPTION
When a modal is closed, it makes a little jump to the left because of hiding/displaying the scrollbars. I've changed the positioning of the modal on sm: to avoid this jump.

See #218