### PR TITLE
Display focus ring only when visible

### DIFF
--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -56,7 +56,7 @@ const boxStyles = tv({
         "group-invalid:border-danger/70 group-invalid:bg-danger group-invalid:text-danger-fg",
       ],
     },
-    isFocused: {
+    isFocusVisible: {
       true: [
         "border-primary ring-4 ring-primary/20",
         "group-invalid:border-danger/70 group-invalid:text-danger-fg group-invalid:ring-danger/20",


### PR DESCRIPTION
I don't know if you deliberately added this behavior. I find the current checkbox's focus behavior a bit strange and uncommon. When using isFocusVisible, the focus ring is now only shown when the checkbox actually has the keyboard focus.