### PR TITLE
Fix build script path typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "next build",
     "format": "biome lint --fix && biome check --write",
     "format:unsafe": "biome check --unsafe --write",
-    "build:everything": "rm -rf pubilc/registry && bun run build:registry",
+    "build:everything": "rm -rf public/registry && bun run build:registry",
     "bb": "bun run format && bun run build:everything",
     "start": "next start",
     "preview": "bun run build && next start",


### PR DESCRIPTION
## Summary
- fix typo in build script path

## Testing
- `npm run lint` *(fails: Formatter would have printed the following content)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683fe54529e88320b38754c7562e7abc