### PR TITLE
Fix README contributor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Design pages faster than ever with [Intent Blocks](https://blocks.intentui.com).
 
 ## Contributing
 
-Make sure to check out the [contributing guide](https://intentui.com/docs/2.x/prologue/contribution-guide), and join our awesome list of [contributors](https://github.com/irsyadadl/d./graphs/contributors). We can't wait to see what you bring to the table!
+Make sure to check out the [contributing guide](https://intentui.com/docs/2.x/prologue/contribution-guide), and join our awesome list of [contributors](https://github.com/irsyadadl/intentui/graphs/contributors). We can't wait to see what you bring to the table!
 
 ## License
-Licensed under the [MIT license](https://github.com/irsyadadl/d./blob/main/LICENSE), so feel free to tweak, share, and remix as long as you give the proper shout-out!
+Licensed under the [MIT license](https://github.com/irsyadadl/intentui/blob/main/LICENSE), so feel free to tweak, share, and remix as long as you give the proper shout-out!


### PR DESCRIPTION
## Summary
- fix broken GitHub links in README

## Testing
- `bun run lint` *(fails: formatting in generated files)*

------
https://chatgpt.com/codex/tasks/task_e_683fe683f1548320bcf9c245b047470b