### PR TITLE
fix(note): invalid grid column layout

### DIFF
--- a/src/components/ui/note.tsx
+++ b/src/components/ui/note.tsx
@@ -20,7 +20,7 @@ const Note = ({ indicator = true, intent = "default", className, ...props }: Not
   return (
     <div
       className={twMerge([
-        "inset-ring-1 inset-ring-current/10 grid w-full grid-cols-[1fr_auto] gap-3 overflow-hidden rounded-lg p-4 sm:text-sm/6",
+        "inset-ring-1 inset-ring-current/10 grid w-full grid-cols-[auto_1fr] gap-3 overflow-hidden rounded-lg p-4 sm:text-sm/6",
         "[&_a]:underline hover:[&_a]:underline **:[strong]:font-semibold",
         intent === "default" &&
           "border-border bg-secondary/20 text-secondary-fg **:data-[slot=icon]:text-secondary-fg dark:**:data-[slot=icon]:text-secondary-fg [&_a]:text-secondary-fg dark:[&_a]:text-secondary-fg",


### PR DESCRIPTION
This fixes the invalid grid column layout present in the container of the note component which results in the bug as seen below:

Before:
![image](https://github.com/user-attachments/assets/2b9cfcb7-0891-4b38-95cf-c9ac5c5773d6)

After:
![image](https://github.com/user-attachments/assets/8d48aecd-f5dd-4c10-8e0c-b578ad014777)