### PR TITLE
Making "errorMessage" props to be accepted directly on Checkbox

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -37,7 +37,7 @@ const CheckboxGroup = ({ className, children, ...props }: CheckboxGroupProps) =>
   )
 }
 
-interface CheckboxProps extends CheckboxPrimitiveProps, Pick<FieldProps, "label" | "description"> {}
+interface CheckboxProps extends CheckboxPrimitiveProps, Pick<FieldProps, "label" | "description" | "errorMessage"> {}
 
 const Checkbox = ({ className, children, description, label, ...props }: CheckboxProps) => {
   return (


### PR DESCRIPTION
Hello,

This commit modifies the CheckboxProps type in the checkbox.tsx component file to add "errorMessage" to the type. This enables the ability to directly pass an error message to the Checkbox itself.

Does this looks good for you ?