### PR TITLE
fix(number-field): make group consistent with text-field group

### DIFF
--- a/src/components/ui/number-field.tsx
+++ b/src/components/ui/number-field.tsx
@@ -45,7 +45,7 @@ const NumberField = ({
   return (
     <NumberFieldPrimitive
       {...props}
-      className={composeTailwindRenderProps(className, "group flex flex-col gap-y-1.5")}
+      className={composeTailwindRenderProps(className, "group flex flex-col gap-y-1 *:data-[slot=label]:font-medium")}
     >
       {label && <Label>{label}</Label>}
       <FieldGroup


### PR DESCRIPTION
This makes the styling of the number-field group consistent with that of the text-field group ensuring that both input fields look consistent when being used together in e.g. a form.