### PR TITLE
Fix: missing `radius-*` tokens in `base-theme.ts`

### DIFF
--- a/src/scripts/styles/base-theme.ts
+++ b/src/scripts/styles/base-theme.ts
@@ -49,4 +49,12 @@ export const baseTheme = {
   "color-chart-3": "var(--chart-3)",
   "color-chart-4": "var(--chart-4)",
   "color-chart-5": "var(--chart-5)",
+  "radius-xs": "var(--radius-xs)",
+  "radius-sm": "var(--radius-sm)",
+  "radius-md": "var(--radius-md)",
+  "radius-lg": "var(--radius-lg)",
+  "radius-xl": "var(--radius-xl)",
+  "radius-2xl": "var(--radius-2xl)",
+  "radius-3xl": "var(--radius-3xl)",
+  "radius-4xl": "var(--radius-4xl)",
 }


### PR DESCRIPTION
When running `npx shadcn@latest init @intentui/theme-default`, the generated CSS ignored our custom `radius-*` values defined in `:root` and used shadcn's defaults in `@theme inline`:
```css
--radius-lg: var(--radius);
--radius-sm: calc(var(--radius) - 4px);
```
This PR fixes it to respect our values:
```css
--radius-lg: var(--radius-lg);
--radius-sm: var(--radius-sm);
```

## Root Cause
- [`default.ts`](src/scripts/styles/default.ts) defines custom `radius-*` values in `:root`
- [`base-theme.ts`](src/scripts/styles/base-theme.ts) had no corresponding `radius-*` tokens in `@theme inline`
- This mismatch caused shadcn to inject its own defaults instead of using our custom values

## Fix
Add all `radius-*` tokens to `base-theme.ts` .

## Testing
1. Run `bun preview`
2. Create a Vite project and run `npx shadcn@latest init http://localhost:3000/r/theme-default.json`
3. Verify `@theme inline` in generated CSS contains `--radius-*: var(--radius-*)`

Notes: I didn't commit changes from `bun run registry:generate` (`registry.json` ) to avoid unrelated changes.