### PR TITLE
Ignore hotkey if user is in editor

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,7 +1,14 @@
-"use client"
+'use client';
 
-import { ChevronDownIcon } from "@heroicons/react/24/solid"
-import { createContext, use, useCallback, useEffect, useMemo, useState } from "react"
+import { ChevronDownIcon } from '@heroicons/react/24/solid';
+import {
+  createContext,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import type {
   ButtonProps,
   DisclosureGroupProps,
@@ -10,7 +17,7 @@ import type {
   LinkProps,
   LinkRenderProps,
   SeparatorProps as SidebarSeparatorProps,
-} from "react-aria-components"
+} from 'react-aria-components';
 import {
   composeRenderProps,
   Disclosure,
@@ -21,46 +28,46 @@ import {
   Separator,
   Text,
   Button as Trigger,
-} from "react-aria-components"
-import { twJoin, twMerge } from "tailwind-merge"
-import { SheetContent } from "@/components/ui/sheet"
-import { useIsMobile } from "@/hooks/use-mobile"
-import { cx } from "@/lib/primitive"
-import { Button } from "./button"
-import { Link } from "./link"
-import { Tooltip, TooltipContent } from "./tooltip"
+} from 'react-aria-components';
+import { twJoin, twMerge } from 'tailwind-merge';
+import { SheetContent } from '@/components/ui/sheet';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cx } from '@/lib/primitive';
+import { Button } from './button';
+import { Link } from './link';
+import { Tooltip, TooltipContent } from './tooltip';
 
-const SIDEBAR_WIDTH = "17rem"
-const SIDEBAR_WIDTH_DOCK = "3.25rem"
-const SIDEBAR_COOKIE_NAME = "sidebar_state"
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+const SIDEBAR_WIDTH = '17rem';
+const SIDEBAR_WIDTH_DOCK = '3.25rem';
+const SIDEBAR_COOKIE_NAME = 'sidebar_state';
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 
 type SidebarContextProps = {
-  state: "expanded" | "collapsed"
-  open: boolean
-  setOpen: (open: boolean) => void
-  isOpenOnMobile: boolean
-  setIsOpenOnMobile: (open: boolean) => void
-  isMobile: boolean
-  toggleSidebar: () => void
-}
+  state: 'expanded' | 'collapsed';
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  isOpenOnMobile: boolean;
+  setIsOpenOnMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
 
-const SidebarContext = createContext<SidebarContextProps | null>(null)
+const SidebarContext = createContext<SidebarContextProps | null>(null);
 
 const useSidebar = () => {
-  const context = use(SidebarContext)
+  const context = use(SidebarContext);
   if (!context) {
-    throw new Error("useSidebar must be used within a SidebarProvider.")
+    throw new Error('useSidebar must be used within a SidebarProvider.');
   }
 
-  return context
-}
+  return context;
+};
 
-interface SidebarProviderProps extends React.ComponentProps<"div"> {
-  defaultOpen?: boolean
-  isOpen?: boolean
-  shortcut?: string
-  onOpenChange?: (open: boolean) => void
+interface SidebarProviderProps extends React.ComponentProps<'div'> {
+  defaultOpen?: boolean;
+  isOpen?: boolean;
+  shortcut?: string;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const SidebarProvider = ({
@@ -70,48 +77,59 @@ const SidebarProvider = ({
   className,
   style,
   children,
-  shortcut = "b",
+  shortcut = 'b',
   ref,
   ...props
 }: SidebarProviderProps) => {
-  const [openMobile, setOpenMobile] = useState(false)
+  const [openMobile, setOpenMobile] = useState(false);
 
-  const [internalOpenState, setInternalOpenState] = useState(defaultOpen)
-  const open = openProp ?? internalOpenState
+  const [internalOpenState, setInternalOpenState] = useState(defaultOpen);
+  const open = openProp ?? internalOpenState;
   const setOpen = useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
-      const openState = typeof value === "function" ? value(open) : value
+      const openState = typeof value === 'function' ? value(open) : value;
 
       if (setOpenProp) {
-        setOpenProp(openState)
+        setOpenProp(openState);
       } else {
-        setInternalOpenState(openState)
+        setInternalOpenState(openState);
       }
 
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
-    [setOpenProp, open],
-  )
+    [setOpenProp, open]
+  );
 
-  const isMobile = useIsMobile()
+  const isMobile = useIsMobile();
 
   const toggleSidebar = useCallback(() => {
-    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
-  }, [isMobile, setOpen])
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+  }, [isMobile, setOpen]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === shortcut && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault()
-        toggleSidebar()
+        const activeElement = document.activeElement;
+
+        // Check if user is in a text input context
+        const isInTextInput =
+          activeElement instanceof HTMLInputElement ||
+          activeElement instanceof HTMLTextAreaElement ||
+          activeElement?.getAttribute('contenteditable') === 'true' ||
+          activeElement?.getAttribute('role') === 'textbox';
+
+        if (!isInTextInput) {
+          event.preventDefault();
+          toggleSidebar();
+        }
       }
-    }
+    };
 
-    window.addEventListener("keydown", handleKeyDown)
-    return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [toggleSidebar, shortcut])
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [toggleSidebar, shortcut]);
 
-  const state = open ? "expanded" : "collapsed"
+  const state = open ? 'expanded' : 'collapsed';
 
   const contextValue = useMemo<SidebarContextProps>(
     () => ({
@@ -123,11 +141,11 @@ const SidebarProvider = ({
       setIsOpenOnMobile: setOpenMobile,
       toggleSidebar,
     }),
-    [state, open, setOpen, isMobile, openMobile, toggleSidebar],
-  )
+    [state, open, setOpen, isMobile, openMobile, toggleSidebar]
+  );
 
   if (isMobile === undefined) {
-    return null
+    return null;
   }
 
   return (
@@ -135,16 +153,16 @@ const SidebarProvider = ({
       <div
         style={
           {
-            "--sidebar-width": SIDEBAR_WIDTH,
-            "--sidebar-width-dock": SIDEBAR_WIDTH_DOCK,
+            '--sidebar-width': SIDEBAR_WIDTH,
+            '--sidebar-width-dock': SIDEBAR_WIDTH_DOCK,
             ...style,
           } as React.CSSProperties
         }
         className={twMerge(
-          "@container **:data-[slot=icon]:shrink-0",
-          "flex w-full text-sidebar-fg",
-          "group/sidebar-root peer/sidebar-root has-data-[intent=inset]:bg-sidebar dark:has-data-[intent=inset]:bg-bg",
-          className,
+          '@container **:data-[slot=icon]:shrink-0',
+          'flex w-full text-sidebar-fg',
+          'group/sidebar-root peer/sidebar-root has-data-[intent=inset]:bg-sidebar dark:has-data-[intent=inset]:bg-bg',
+          className
         )}
         ref={ref}
         {...props}
@@ -152,41 +170,41 @@ const SidebarProvider = ({
         {children}
       </div>
     </SidebarContext>
-  )
-}
+  );
+};
 
-interface SidebarProps extends React.ComponentProps<"div"> {
-  intent?: "default" | "float" | "inset"
-  collapsible?: "hidden" | "dock" | "none"
-  side?: "left" | "right"
-  closeButton?: boolean
+interface SidebarProps extends React.ComponentProps<'div'> {
+  intent?: 'default' | 'float' | 'inset';
+  collapsible?: 'hidden' | 'dock' | 'none';
+  side?: 'left' | 'right';
+  closeButton?: boolean;
 }
 
 const Sidebar = ({
   children,
   closeButton = true,
-  collapsible = "hidden",
-  side = "left",
-  intent = "default",
+  collapsible = 'hidden',
+  side = 'left',
+  intent = 'default',
   className,
   ...props
 }: SidebarProps) => {
-  const { isMobile, state, isOpenOnMobile, setIsOpenOnMobile } = useSidebar()
-  if (collapsible === "none") {
+  const { isMobile, state, isOpenOnMobile, setIsOpenOnMobile } = useSidebar();
+  if (collapsible === 'none') {
     return (
       <div
         data-intent={intent}
         data-collapsible="none"
         data-slot="sidebar"
         className={twMerge(
-          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-fg",
-          className,
+          'flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-fg',
+          className
         )}
         {...props}
       >
         {children}
       </div>
-    )
+    );
   }
 
   if (isMobile) {
@@ -206,13 +224,13 @@ const Sidebar = ({
           {children}
         </SheetContent>
       </>
-    )
+    );
   }
 
   return (
     <div
       data-state={state}
-      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-collapsible={state === 'collapsed' ? collapsible : ''}
       data-intent={intent}
       data-side={side}
       data-slot="sidebar"
@@ -223,36 +241,37 @@ const Sidebar = ({
         data-slot="sidebar-gap"
         aria-hidden="true"
         className={twMerge([
-          "w-(--sidebar-width) group-data-[collapsible=hidden]:w-0",
-          "group-data-[side=right]:rotate-180",
-          "relative h-svh bg-transparent transition-[width] duration-200 ease-linear",
-          intent === "default" && "group-data-[collapsible=dock]:w-(--sidebar-width-dock)",
-          intent === "float" &&
-            "group-data-[collapsible=dock]:w-[calc(var(--sidebar-width-dock)+--spacing(4))]",
-          intent === "inset" &&
-            "group-data-[collapsible=dock]:w-[calc(var(--sidebar-width-dock)+--spacing(2))]",
+          'w-(--sidebar-width) group-data-[collapsible=hidden]:w-0',
+          'group-data-[side=right]:rotate-180',
+          'relative h-svh bg-transparent transition-[width] duration-200 ease-linear',
+          intent === 'default' &&
+            'group-data-[collapsible=dock]:w-(--sidebar-width-dock)',
+          intent === 'float' &&
+            'group-data-[collapsible=dock]:w-[calc(var(--sidebar-width-dock)+--spacing(4))]',
+          intent === 'inset' &&
+            'group-data-[collapsible=dock]:w-[calc(var(--sidebar-width-dock)+--spacing(2))]',
         ])}
       />
       <div
         data-slot="sidebar-container"
         className={twMerge(
-          "fixed inset-y-0 z-10 hidden w-(--sidebar-width) bg-sidebar",
-          "not-has-data-[slot=sidebar-footer]:pb-2",
-          "transition-[left,right,width] duration-200 ease-linear",
-          "md:flex",
-          side === "left" &&
-            "left-0 group-data-[collapsible=hidden]:left-[calc(var(--sidebar-width)*-1)]",
-          side === "right" &&
-            "right-0 group-data-[collapsible=hidden]:right-[calc(var(--sidebar-width)*-1)]",
-          intent === "float" &&
-            "bg-bg p-2 group-data-[collapsible=dock]:w-[calc(--spacing(4)+2px)]",
-          intent === "inset" &&
-            "bg-sidebar group-data-[collapsible=dock]:w-[calc(var(--sidebar-width-dock)+--spacing(2)+2px)] dark:bg-bg",
-          intent === "default" && [
-            "group-data-[collapsible=dock]:w-(--sidebar-width-dock)",
-            "border-sidebar-border group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          'fixed inset-y-0 z-10 hidden w-(--sidebar-width) bg-sidebar',
+          'not-has-data-[slot=sidebar-footer]:pb-2',
+          'transition-[left,right,width] duration-200 ease-linear',
+          'md:flex',
+          side === 'left' &&
+            'left-0 group-data-[collapsible=hidden]:left-[calc(var(--sidebar-width)*-1)]',
+          side === 'right' &&
+            'right-0 group-data-[collapsible=hidden]:right-[calc(var(--sidebar-width)*-1)]',
+          intent === 'float' &&
+            'bg-bg p-2 group-data-[collapsible=dock]:w-[calc(--spacing(4)+2px)]',
+          intent === 'inset' &&
+            'bg-sidebar group-data-[collapsible=dock]:w-[calc(var(--sidebar-width-dock)+--spacing(2)+2px)] dark:bg-bg',
+          intent === 'default' && [
+            'group-data-[collapsible=dock]:w-(--sidebar-width-dock)',
+            'border-sidebar-border group-data-[side=left]:border-r group-data-[side=right]:border-l',
           ],
-          className,
+          className
         )}
         {...props}
       >
@@ -260,99 +279,112 @@ const Sidebar = ({
           data-sidebar="default"
           data-slot="sidebar-inner"
           className={twJoin(
-            "flex h-full w-full flex-col text-sidebar-fg",
-            "group-data-[intent=inset]:bg-sidebar dark:group-data-[intent=inset]:bg-bg",
-            "group-data-[intent=float]:rounded-lg group-data-[intent=float]:border group-data-[intent=float]:border-sidebar-border group-data-[intent=float]:bg-sidebar group-data-[intent=float]:shadow-xs",
+            'flex h-full w-full flex-col text-sidebar-fg',
+            'group-data-[intent=inset]:bg-sidebar dark:group-data-[intent=inset]:bg-bg',
+            'group-data-[intent=float]:rounded-lg group-data-[intent=float]:border group-data-[intent=float]:border-sidebar-border group-data-[intent=float]:bg-sidebar group-data-[intent=float]:shadow-xs'
           )}
         >
           {children}
         </div>
       </div>
     </div>
-  )
-}
+  );
+};
 
-const SidebarHeader = ({ className, ref, ...props }: React.ComponentProps<"div">) => {
-  const { state } = useSidebar()
+const SidebarHeader = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'div'>) => {
+  const { state } = useSidebar();
   return (
     <div
       ref={ref}
       data-slot="sidebar-header"
       className={twMerge(
-        "flex flex-col gap-2 p-2.5 [.border-b]:border-sidebar-border",
-        "in-data-[intent=inset]:p-4",
-        state === "collapsed" ? "items-center p-2.5" : "p-4",
-        className,
+        'flex flex-col gap-2 p-2.5 [.border-b]:border-sidebar-border',
+        'in-data-[intent=inset]:p-4',
+        state === 'collapsed' ? 'items-center p-2.5' : 'p-4',
+        className
       )}
       {...props}
     />
-  )
-}
+  );
+};
 
-const SidebarFooter = ({ className, ...props }: React.ComponentProps<"div">) => {
+const SidebarFooter = ({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) => {
   return (
     <div
       data-slot="sidebar-footer"
       className={twMerge([
-        "mt-auto flex shrink-0 items-center justify-center p-4 **:data-[slot=chevron]:text-muted-fg",
-        "in-data-[intent=inset]:px-6 in-data-[intent=inset]:py-4",
+        'mt-auto flex shrink-0 items-center justify-center p-4 **:data-[slot=chevron]:text-muted-fg',
+        'in-data-[intent=inset]:px-6 in-data-[intent=inset]:py-4',
         className,
       ])}
       {...props}
     />
-  )
-}
+  );
+};
 
-const SidebarContent = ({ className, ...props }: React.ComponentProps<"div">) => {
-  const { state } = useSidebar()
+const SidebarContent = ({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) => {
+  const { state } = useSidebar();
   return (
     <div
       data-slot="sidebar-content"
       className={twMerge(
-        "flex min-h-0 flex-1 scroll-mb-96 flex-col overflow-auto *:data-[slot=sidebar-section]:border-l-0",
-        state === "collapsed" ? "items-center" : "mask-b-from-95%",
-        className,
+        'flex min-h-0 flex-1 scroll-mb-96 flex-col overflow-auto *:data-[slot=sidebar-section]:border-l-0',
+        state === 'collapsed' ? 'items-center' : 'mask-b-from-95%',
+        className
       )}
       {...props}
     >
       {props.children}
     </div>
-  )
-}
+  );
+};
 
-const SidebarSectionGroup = ({ className, ...props }: React.ComponentProps<"section">) => {
-  const { state, isMobile } = useSidebar()
-  const collapsed = state === "collapsed" && !isMobile
+const SidebarSectionGroup = ({
+  className,
+  ...props
+}: React.ComponentProps<'section'>) => {
+  const { state, isMobile } = useSidebar();
+  const collapsed = state === 'collapsed' && !isMobile;
   return (
     <section
       data-slot="sidebar-section-group"
       className={twMerge(
-        "flex w-full min-w-0 flex-col gap-y-0.5",
-        collapsed && "items-center justify-center",
-        className,
+        'flex w-full min-w-0 flex-col gap-y-0.5',
+        collapsed && 'items-center justify-center',
+        className
       )}
       {...props}
     />
-  )
-}
+  );
+};
 
-interface SidebarSectionProps extends React.ComponentProps<"div"> {
-  label?: string
+interface SidebarSectionProps extends React.ComponentProps<'div'> {
+  label?: string;
 }
 
 const SidebarSection = ({ className, ...props }: SidebarSectionProps) => {
-  const { state } = useSidebar()
+  const { state } = useSidebar();
   return (
     <div
       data-slot="sidebar-section"
       className={twMerge(
-        "col-span-full flex min-w-0 flex-col gap-y-0.5 **:data-[slot=sidebar-section]:**:gap-y-0",
-        "in-data-[state=collapsed]:p-2 p-4",
-        className,
+        'col-span-full flex min-w-0 flex-col gap-y-0.5 **:data-[slot=sidebar-section]:**:gap-y-0',
+        'in-data-[state=collapsed]:p-2 p-4',
+        className
       )}
       {...props}
     >
-      {state !== "collapsed" && "label" in props && (
+      {state !== 'collapsed' && 'label' in props && (
         <Header className="mb-1 flex shrink-0 items-center rounded-md px-2 font-medium text-sidebar-fg/70 text-xs/6 outline-none ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear *:data-[slot=icon]:size-4 *:data-[slot=icon]:shrink-0 group-data-[collapsible=dock]:-mt-8 group-data-[collapsible=dock]:opacity-0">
           {props.label}
         </Header>
@@ -364,18 +396,22 @@ const SidebarSection = ({ className, ...props }: SidebarSectionProps) => {
         {props.children}
       </div>
     </div>
-  )
-}
+  );
+};
 
-interface SidebarItemProps extends Omit<React.ComponentProps<typeof Link>, "children"> {
-  isCurrent?: boolean
+interface SidebarItemProps
+  extends Omit<React.ComponentProps<typeof Link>, 'children'> {
+  isCurrent?: boolean;
   children?:
     | React.ReactNode
     | ((
-        values: LinkRenderProps & { defaultChildren: React.ReactNode; isCollapsed: boolean },
-      ) => React.ReactNode)
-  badge?: string | number | undefined
-  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+        values: LinkRenderProps & {
+          defaultChildren: React.ReactNode;
+          isCollapsed: boolean;
+        }
+      ) => React.ReactNode);
+  badge?: string | number | undefined;
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>;
 }
 
 const SidebarItem = ({
@@ -387,45 +423,48 @@ const SidebarItem = ({
   ref,
   ...props
 }: SidebarItemProps) => {
-  const { state, isMobile } = useSidebar()
-  const isCollapsed = state === "collapsed" && !isMobile
+  const { state, isMobile } = useSidebar();
+  const isCollapsed = state === 'collapsed' && !isMobile;
   const link = (
     <Link
       ref={ref}
       data-slot="sidebar-item"
-      aria-current={isCurrent ? "page" : undefined}
+      aria-current={isCurrent ? 'page' : undefined}
       className={composeRenderProps(
         className,
         (className, { isPressed, isFocusVisible, isHovered, isDisabled }) =>
           twMerge([
-            "href" in props ? "cursor-pointer" : "cursor-default",
-            "w-full min-w-0 items-center rounded-lg text-left font-medium text-base/6 text-sidebar-fg",
-            "group/sidebar-item relative col-span-full overflow-hidden focus-visible:outline-hidden",
+            'href' in props ? 'cursor-pointer' : 'cursor-default',
+            'w-full min-w-0 items-center rounded-lg text-left font-medium text-base/6 text-sidebar-fg',
+            'group/sidebar-item relative col-span-full overflow-hidden focus-visible:outline-hidden',
             "**:data-[slot=icon]:shrink-0 [&_[data-slot='icon']:not([class*='size-'])]:size-5 sm:[&_[data-slot='icon']:not([class*='size-'])]:size-4 [&_[data-slot='icon']:not([class*='text-'])]:text-muted-fg",
-            "**:last:data-[slot=icon]:size-5 sm:**:last:data-[slot=icon]:size-4",
+            '**:last:data-[slot=icon]:size-5 sm:**:last:data-[slot=icon]:size-4',
             "[&_[data-slot='icon']:not([class*='size-'])]:size-4 [&_[data-slot='icon']:not([class*='size-'])]:*:size-5",
-            "*:data-[slot=avatar]:*:size-5 *:data-[slot=avatar]:size-5",
-            "has-data-[slot=avatar]:has-data-[slot=sidebar-label]:gap-x-2 has-data-[slot=icon]:has-data-[slot=sidebar-label]:gap-x-2",
-            "grid grid-cols-[auto_1fr_1.5rem_0.5rem_auto] **:last:data-[slot=icon]:ml-auto supports-[grid-template-columns:subgrid]:grid-cols-subgrid sm:text-sm/5",
-            "p-2 has-[a]:p-0",
-            "[--sidebar-current-bg:var(--color-sidebar-primary)] [--sidebar-current-fg:var(--color-sidebar-primary-fg)]",
+            '*:data-[slot=avatar]:*:size-5 *:data-[slot=avatar]:size-5',
+            'has-data-[slot=avatar]:has-data-[slot=sidebar-label]:gap-x-2 has-data-[slot=icon]:has-data-[slot=sidebar-label]:gap-x-2',
+            'grid grid-cols-[auto_1fr_1.5rem_0.5rem_auto] **:last:data-[slot=icon]:ml-auto supports-[grid-template-columns:subgrid]:grid-cols-subgrid sm:text-sm/5',
+            'p-2 has-[a]:p-0',
+            '[--sidebar-current-bg:var(--color-sidebar-primary)] [--sidebar-current-fg:var(--color-sidebar-primary-fg)]',
             isCurrent &&
               "font-medium text-(--sidebar-current-fg) hover:bg-(--sidebar-current-bg) hover:text-(--sidebar-current-fg) [&_.text-muted-fg]:text-fg/80 [&_[data-slot='icon']:not([class*='text-'])]:text-(--sidebar-current-fg) hover:[&_[data-slot='icon']:not([class*='text-'])]:text-(--sidebar-current-fg)",
-            isFocusVisible && "inset-ring inset-ring-sidebar-ring outline-hidden",
+            isFocusVisible &&
+              'inset-ring inset-ring-sidebar-ring outline-hidden',
             (isPressed || isHovered) &&
               "bg-sidebar-accent text-sidebar-accent-fg [&_[data-slot='icon']:not([class*='text-'])]:text-sidebar-accent-fg",
-            isDisabled && "opacity-50",
+            isDisabled && 'opacity-50',
             className,
-          ]),
+          ])
       )}
       {...props}
     >
       {(values) => (
         <>
-          {typeof children === "function" ? children({ ...values, isCollapsed }) : children}
+          {typeof children === 'function'
+            ? children({ ...values, isCollapsed })
+            : children}
 
           {badge &&
-            (state !== "collapsed" ? (
+            (state !== 'collapsed' ? (
               <span
                 data-slot="sidebar-badge"
                 className="absolute inset-ring-1 inset-ring-sidebar-border inset-y-1/2 right-1.5 h-5.5 w-auto -translate-y-1/2 rounded-full bg-fg/5 px-2 text-[10px]/5.5 group-hover/sidebar-item:inset-ring-muted-fg/30 group-current:inset-ring-transparent"
@@ -441,11 +480,11 @@ const SidebarItem = ({
         </>
       )}
     </Link>
-  )
-  if (typeof tooltip === "string") {
+  );
+  if (typeof tooltip === 'string') {
     tooltip = {
       children: tooltip,
-    }
+    };
   }
 
   return (
@@ -460,11 +499,11 @@ const SidebarItem = ({
         {...tooltip}
       />
     </Tooltip>
-  )
-}
+  );
+};
 
 interface SidebarLinkProps extends LinkProps {
-  ref?: React.RefObject<HTMLAnchorElement>
+  ref?: React.RefObject<HTMLAnchorElement>;
 }
 
 const SidebarLink = ({ className, ref, ...props }: SidebarLinkProps) => {
@@ -472,36 +511,40 @@ const SidebarLink = ({ className, ref, ...props }: SidebarLinkProps) => {
     <Link
       ref={ref}
       className={cx(
-        "col-span-full min-w-0 shrink-0 items-center p-2 focus:outline-hidden",
-        "grid grid-cols-[auto_1fr_1.5rem_0.5rem_auto] supports-[grid-template-columns:subgrid]:grid-cols-subgrid",
-        className,
+        'col-span-full min-w-0 shrink-0 items-center p-2 focus:outline-hidden',
+        'grid grid-cols-[auto_1fr_1.5rem_0.5rem_auto] supports-[grid-template-columns:subgrid]:grid-cols-subgrid',
+        className
       )}
       {...props}
     />
-  )
-}
+  );
+};
 
-const SidebarInset = ({ className, ref, ...props }: React.ComponentProps<"main">) => {
+const SidebarInset = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'main'>) => {
   return (
     <main
       data-slot="sidebar-inset"
       ref={ref}
       className={twMerge(
-        "relative flex w-full flex-1 flex-col bg-bg lg:min-w-0",
-        "group-has-data-[intent=inset]/sidebar-root:border group-has-data-[intent=inset]/sidebar-root:border-sidebar-border group-has-data-[intent=inset]/sidebar-root:bg-overlay",
-        "md:group-has-data-[intent=inset]/sidebar-root:m-2",
-        "md:group-has-data-[side=left]:group-has-data-[intent=inset]/sidebar-root:ml-0",
-        "md:group-has-data-[side=right]:group-has-data-[intent=inset]/sidebar-root:mr-0",
-        "md:group-has-data-[intent=inset]/sidebar-root:rounded-2xl",
-        "md:group-has-data-[intent=inset]/sidebar-root:peer-data-[state=collapsed]:ml-2",
-        className,
+        'relative flex w-full flex-1 flex-col bg-bg lg:min-w-0',
+        'group-has-data-[intent=inset]/sidebar-root:border group-has-data-[intent=inset]/sidebar-root:border-sidebar-border group-has-data-[intent=inset]/sidebar-root:bg-overlay',
+        'md:group-has-data-[intent=inset]/sidebar-root:m-2',
+        'md:group-has-data-[side=left]:group-has-data-[intent=inset]/sidebar-root:ml-0',
+        'md:group-has-data-[side=right]:group-has-data-[intent=inset]/sidebar-root:mr-0',
+        'md:group-has-data-[intent=inset]/sidebar-root:rounded-2xl',
+        'md:group-has-data-[intent=inset]/sidebar-root:peer-data-[state=collapsed]:ml-2',
+        className
       )}
       {...props}
     />
-  )
-}
+  );
+};
 
-type SidebarDisclosureGroupProps = DisclosureGroupProps
+type SidebarDisclosureGroupProps = DisclosureGroupProps;
 const SidebarDisclosureGroup = ({
   allowsMultipleExpanded = true,
   className,
@@ -512,36 +555,48 @@ const SidebarDisclosureGroup = ({
       data-slot="sidebar-disclosure-group"
       allowsMultipleExpanded={allowsMultipleExpanded}
       className={cx(
-        "col-span-full flex min-w-0 flex-col gap-y-0.5 in-data-[state=collapsed]:gap-y-1.5",
-        className,
+        'col-span-full flex min-w-0 flex-col gap-y-0.5 in-data-[state=collapsed]:gap-y-1.5',
+        className
       )}
       {...props}
     />
-  )
-}
+  );
+};
 
 interface SidebarDisclosureProps extends DisclosureProps {
-  ref?: React.Ref<HTMLDivElement>
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-const SidebarDisclosure = ({ className, ref, ...props }: SidebarDisclosureProps) => {
-  const { state } = useSidebar()
+const SidebarDisclosure = ({
+  className,
+  ref,
+  ...props
+}: SidebarDisclosureProps) => {
+  const { state } = useSidebar();
   return (
     <Disclosure
       ref={ref}
       data-slot="sidebar-disclosure"
-      className={cx("col-span-full min-w-0", state === "collapsed" ? "px-2" : "px-4", className)}
+      className={cx(
+        'col-span-full min-w-0',
+        state === 'collapsed' ? 'px-2' : 'px-4',
+        className
+      )}
       {...props}
     />
-  )
-}
+  );
+};
 
 interface SidebarDisclosureTriggerProps extends ButtonProps {
-  ref?: React.Ref<HTMLButtonElement>
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-const SidebarDisclosureTrigger = ({ className, ref, ...props }: SidebarDisclosureTriggerProps) => {
-  const { state } = useSidebar()
+const SidebarDisclosureTrigger = ({
+  className,
+  ref,
+  ...props
+}: SidebarDisclosureTriggerProps) => {
+  const { state } = useSidebar();
   return (
     <Heading level={3}>
       <Trigger
@@ -551,26 +606,28 @@ const SidebarDisclosureTrigger = ({ className, ref, ...props }: SidebarDisclosur
           className,
           (className, { isPressed, isFocusVisible, isHovered, isDisabled }) =>
             twMerge(
-              "flex w-full min-w-0 items-center rounded-lg text-left font-medium text-base/6 text-sidebar-fg",
-              "group/sidebar-disclosure-trigger relative col-span-full overflow-hidden focus-visible:outline-hidden",
-              "**:data-[slot=icon]:size-5 **:data-[slot=icon]:shrink-0 **:data-[slot=icon]:text-muted-fg sm:**:data-[slot=icon]:size-4",
-              "**:last:data-[slot=icon]:size-5 sm:**:last:data-[slot=icon]:size-4",
-              "**:data-[slot=avatar]:size-6 sm:**:data-[slot=avatar]:size-5",
-              "col-span-full gap-3 p-2 **:data-[slot=chevron]:text-muted-fg **:last:data-[slot=icon]:ml-auto sm:gap-2 sm:text-sm/5",
+              'flex w-full min-w-0 items-center rounded-lg text-left font-medium text-base/6 text-sidebar-fg',
+              'group/sidebar-disclosure-trigger relative col-span-full overflow-hidden focus-visible:outline-hidden',
+              '**:data-[slot=icon]:size-5 **:data-[slot=icon]:shrink-0 **:data-[slot=icon]:text-muted-fg sm:**:data-[slot=icon]:size-4',
+              '**:last:data-[slot=icon]:size-5 sm:**:last:data-[slot=icon]:size-4',
+              '**:data-[slot=avatar]:size-6 sm:**:data-[slot=avatar]:size-5',
+              'col-span-full gap-3 p-2 **:data-[slot=chevron]:text-muted-fg **:last:data-[slot=icon]:ml-auto sm:gap-2 sm:text-sm/5',
 
-              isFocusVisible && "inset-ring inset-ring-ring/70",
+              isFocusVisible && 'inset-ring inset-ring-ring/70',
               (isPressed || isHovered) &&
-                "bg-sidebar-accent text-sidebar-accent-fg **:data-[slot=chevron]:text-sidebar-accent-fg **:data-[slot=icon]:text-sidebar-accent-fg **:last:data-[slot=icon]:text-sidebar-accent-fg",
-              isDisabled && "opacity-50",
-              className,
-            ),
+                'bg-sidebar-accent text-sidebar-accent-fg **:data-[slot=chevron]:text-sidebar-accent-fg **:data-[slot=icon]:text-sidebar-accent-fg **:last:data-[slot=icon]:text-sidebar-accent-fg',
+              isDisabled && 'opacity-50',
+              className
+            )
         )}
         {...props}
       >
         {(values) => (
           <>
-            {typeof props.children === "function" ? props.children(values) : props.children}
-            {state !== "collapsed" && (
+            {typeof props.children === 'function'
+              ? props.children(values)
+              : props.children}
+            {state !== 'collapsed' && (
               <ChevronDownIcon
                 data-slot="chevron"
                 className="z-10 ml-auto size-3.5 transition-transform duration-200 group-aria-expanded/sidebar-disclosure-trigger:rotate-180"
@@ -580,16 +637,19 @@ const SidebarDisclosureTrigger = ({ className, ref, ...props }: SidebarDisclosur
         )}
       </Trigger>
     </Heading>
-  )
-}
+  );
+};
 
-const SidebarDisclosurePanel = ({ className, ...props }: DisclosurePanelProps) => {
+const SidebarDisclosurePanel = ({
+  className,
+  ...props
+}: DisclosurePanelProps) => {
   return (
     <DisclosurePanel
       data-slot="sidebar-disclosure-panel"
       className={cx(
-        "h-(--disclosure-panel-height) overflow-clip transition-[height] duration-200",
-        className,
+        'h-(--disclosure-panel-height) overflow-clip transition-[height] duration-200',
+        className
       )}
       {...props}
     >
@@ -600,8 +660,8 @@ const SidebarDisclosurePanel = ({ className, ...props }: DisclosurePanelProps) =
         {props.children}
       </div>
     </DisclosurePanel>
-  )
-}
+  );
+};
 
 const SidebarSeparator = ({ className, ...props }: SidebarSeparatorProps) => {
   return (
@@ -609,13 +669,13 @@ const SidebarSeparator = ({ className, ...props }: SidebarSeparatorProps) => {
       data-slot="sidebar-separator"
       orientation="horizontal"
       className={twMerge(
-        "mx-auto h-px w-[calc(var(--sidebar-width)---spacing(10))] border-0 bg-sidebar-border forced-colors:bg-[ButtonBorder]",
-        className,
+        'mx-auto h-px w-[calc(var(--sidebar-width)---spacing(10))] border-0 bg-sidebar-border forced-colors:bg-[ButtonBorder]',
+        className
       )}
       {...props}
     />
-  )
-}
+  );
+};
 
 const SidebarTrigger = ({
   onPress,
@@ -623,17 +683,17 @@ const SidebarTrigger = ({
   children,
   ...props
 }: React.ComponentProps<typeof Button>) => {
-  const { toggleSidebar } = useSidebar()
+  const { toggleSidebar } = useSidebar();
   return (
     <Button
-      aria-label={props["aria-label"] || "Toggle Sidebar"}
+      aria-label={props['aria-label'] || 'Toggle Sidebar'}
       data-slot="sidebar-trigger"
-      intent={props.intent || "plain"}
-      size={props.size || "sq-sm"}
-      className={cx("shrink-0", className)}
+      intent={props.intent || 'plain'}
+      size={props.size || 'sq-sm'}
+      className={cx('shrink-0', className)}
       onPress={(event) => {
-        onPress?.(event)
-        toggleSidebar()
+        onPress?.(event);
+        toggleSidebar();
       }}
       {...props}
     >
@@ -651,11 +711,15 @@ const SidebarTrigger = ({
         </>
       )}
     </Button>
-  )
-}
+  );
+};
 
-const SidebarRail = ({ className, ref, ...props }: React.ComponentProps<"button">) => {
-  const { toggleSidebar } = useSidebar()
+const SidebarRail = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'button'>) => {
+  const { toggleSidebar } = useSidebar();
 
   return !props.children ? (
     <button
@@ -666,23 +730,27 @@ const SidebarRail = ({ className, ref, ...props }: React.ComponentProps<"button"
       tabIndex={-1}
       onClick={toggleSidebar}
       className={twMerge(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 outline-hidden transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 hover:after:bg-transparent group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=hidden]:translate-x-0 group-data-[collapsible=hidden]:hover:bg-sidebar-accent group-data-[collapsible=hidden]:after:left-full",
-        "[[data-side=left][data-collapsible=hidden]_&]:-right-2 [[data-side=right][data-collapsible=hidden]_&]:-left-2",
-        className,
+        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 outline-hidden transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 hover:after:bg-transparent group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
+        'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
+        '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
+        'group-data-[collapsible=hidden]:translate-x-0 group-data-[collapsible=hidden]:hover:bg-sidebar-accent group-data-[collapsible=hidden]:after:left-full',
+        '[[data-side=left][data-collapsible=hidden]_&]:-right-2 [[data-side=right][data-collapsible=hidden]_&]:-left-2',
+        className
       )}
       {...props}
     />
   ) : (
     props.children
-  )
-}
+  );
+};
 
-const SidebarLabel = ({ className, ref, ...props }: React.ComponentProps<typeof Text>) => {
-  const { state, isMobile } = useSidebar()
-  const collapsed = state === "collapsed" && !isMobile
+const SidebarLabel = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<typeof Text>) => {
+  const { state, isMobile } = useSidebar();
+  const collapsed = state === 'collapsed' && !isMobile;
   if (!collapsed) {
     return (
       <Text
@@ -691,38 +759,43 @@ const SidebarLabel = ({ className, ref, ...props }: React.ComponentProps<typeof 
         ref={ref}
         slot="label"
         className={twMerge(
-          "col-start-2 overflow-hidden whitespace-nowrap outline-hidden",
-          className,
+          'col-start-2 overflow-hidden whitespace-nowrap outline-hidden',
+          className
         )}
         {...props}
       >
         {props.children}
       </Text>
-    )
+    );
   }
-  return null
+  return null;
+};
+
+interface SidebarNavProps extends React.ComponentProps<'nav'> {
+  isSticky?: boolean;
 }
 
-interface SidebarNavProps extends React.ComponentProps<"nav"> {
-  isSticky?: boolean
-}
-
-const SidebarNav = ({ isSticky = false, className, ...props }: SidebarNavProps) => {
+const SidebarNav = ({
+  isSticky = false,
+  className,
+  ...props
+}: SidebarNavProps) => {
   return (
     <nav
       data-slot="sidebar-nav"
       className={twMerge(
-        "isolate flex items-center justify-between gap-x-2 px-(--container-padding,--spacing(4)) py-2.5 text-navbar-fg sm:justify-start sm:px-(--gutter,--spacing(4)) md:w-full",
-        isSticky && "static top-0 z-40 group-has-data-[intent=default]/sidebar-root:sticky",
-        className,
+        'isolate flex items-center justify-between gap-x-2 px-(--container-padding,--spacing(4)) py-2.5 text-navbar-fg sm:justify-start sm:px-(--gutter,--spacing(4)) md:w-full',
+        isSticky &&
+          'static top-0 z-40 group-has-data-[intent=default]/sidebar-root:sticky',
+        className
       )}
       {...props}
     />
-  )
-}
+  );
+};
 
 interface SidebarMenuTriggerProps extends ButtonProps {
-  alwaysVisible?: boolean
+  alwaysVisible?: boolean;
 }
 const SidebarMenuTrigger = ({
   alwaysVisible = false,
@@ -733,16 +806,16 @@ const SidebarMenuTrigger = ({
     <Trigger
       className={cx(
         !alwaysVisible &&
-          "opacity-0 pressed:opacity-100 group-hover/sidebar-item:opacity-100 group-focus-visible/sidebar-item:opacity-100 group/sidebar-item:pressed:opacity-100",
-        "absolute right-0 flex h-full w-[calc(var(--sidebar-width)-90%)] items-center justify-end pr-2.5 outline-hidden",
+          'opacity-0 pressed:opacity-100 group-hover/sidebar-item:opacity-100 group-focus-visible/sidebar-item:opacity-100 group/sidebar-item:pressed:opacity-100',
+        'absolute right-0 flex h-full w-[calc(var(--sidebar-width)-90%)] items-center justify-end pr-2.5 outline-hidden',
         "**:data-[slot=icon]:shrink-0 [&_[data-slot='icon']:not([class*='size-'])]:size-5 sm:[&_[data-slot='icon']:not([class*='size-'])]:size-4",
-        "pressed:text-fg text-muted-fg hover:text-fg",
-        className,
+        'pressed:text-fg text-muted-fg hover:text-fg',
+        className
       )}
       {...props}
     />
-  )
-}
+  );
+};
 
 export type {
   SidebarProviderProps,
@@ -755,7 +828,7 @@ export type {
   SidebarSeparatorProps,
   SidebarLinkProps,
   SidebarDisclosureTriggerProps,
-}
+};
 
 export {
   SidebarProvider,
@@ -779,4 +852,4 @@ export {
   SidebarRail,
   SidebarMenuTrigger,
   useSidebar,
-}
+};


### PR DESCRIPTION
This fixes an issue where the sidebar is opened / closed even when the user has the text editor in focus. CMD + b is hotkey for bold text. 

```ts
  useEffect(() => {
    const handleKeyDown = (event: KeyboardEvent) => {
      if (event.key === shortcut && (event.metaKey || event.ctrlKey)) {
        const activeElement = document.activeElement;

        // Check if user is in a text input context
        const isInTextInput =
          activeElement instanceof HTMLInputElement ||
          activeElement instanceof HTMLTextAreaElement ||
          activeElement?.getAttribute('contenteditable') === 'true' ||
          activeElement?.getAttribute('role') === 'textbox';

        if (!isInTextInput) {
          event.preventDefault();
          toggleSidebar();
        }
      }
    };

```

The project has generally problem with formatting. If I use "pnpm format", there are many files with wrong format.