### PR TITLE
docs: add MultipleSelectContent to MultipleSelect example for correct…

### DIFF
--- a/src/content/docs/components/pickers/multiple-select.mdx
+++ b/src/content/docs/components/pickers/multiple-select.mdx
@@ -41,9 +41,9 @@ import { MultipleSelect, MultipleSelectItem, MultipleSelectLabel, MultipleSelect
   <MultipleSelectContent items={fruits}>
     {(item) => {
       return (
-        <MultipleSelect.Item textValue={item.name}>
+        <MultipleSelectItem textValue={item.name}>
           {item.name}
-        </MultipleSelect.Item>
+        </MultipleSelectItem>
       )
     }}
   </MultipleSelectContent>

--- a/src/content/docs/components/pickers/multiple-select.mdx
+++ b/src/content/docs/components/pickers/multiple-select.mdx
@@ -37,15 +37,16 @@ import { MultipleSelect, MultipleSelectItem, MultipleSelectLabel, MultipleSelect
   className="min-w-2xs max-w-min"
   placeholder="Select fruits"
   aria-label="Fruits"
-  items={fruits}
 >
-  {(item) => {
-    return (
-      <MultipleSelect.Item textValue={item.name}>
-        {item.name}
-      </MultipleSelect.Item>
-    )
-  }}
+  <MultipleSelectContent items={fruits}>
+    {(item) => {
+      return (
+        <MultipleSelect.Item textValue={item.name}>
+          {item.name}
+        </MultipleSelect.Item>
+      )
+    }}
+  </MultipleSelectContent>
 </MultipleSelect>
 ```
 


### PR DESCRIPTION
Docs show using the items prop directly on MultipleSelect but MultipleSelect does not take an items prop or provide the item children. MultipleSelectContent is required:

Current example:
```
<MultipleSelect
  className="min-w-2xs max-w-min"
  placeholder="Select fruits"
  aria-label="Fruits"
  items={fruits}
>
  {(item) => {
    return (
      <MultipleSelect.Item textValue={item.name}>
        {item.name}
      </MultipleSelect.Item>
    )
  }}
</MultipleSelect>
```

Correct usage:
```
<MultipleSelect
  className="min-w-2xs max-w-min"
  placeholder="Select fruits"
  aria-label="Fruits"
>
  <MultipleSelectContent items={fruits}>
    {(item) => {
      return (
        <MultipleSelect.Item textValue={item.name}>
          {item.name}
        </MultipleSelect.Item>
      )
    }}
  </MultipleSelectContent>
</MultipleSelect>
```