### PR TITLE
fix: add "use client" directive to client-side components

### DIFF
--- a/src/components/docs/visualizations/line-chart/line-chart-custom-colors-demo.tsx
+++ b/src/components/docs/visualizations/line-chart/line-chart-custom-colors-demo.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useMemo } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { LineChart } from "@/components/ui/line-chart"

--- a/src/components/docs/visualizations/line-chart/line-chart-stacked-demo.tsx
+++ b/src/components/docs/visualizations/line-chart/line-chart-stacked-demo.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useMemo } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { LineChart } from "@/components/ui/line-chart"

--- a/src/components/ui/leaderboard.tsx
+++ b/src/components/ui/leaderboard.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { Label, type LabelProps, ProgressBar, type ProgressBarProps } from "react-aria-components"
 import { twJoin, twMerge } from "tailwind-merge"
 import { cx } from "@/lib/primitive"

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useLayoutEffect, useRef } from "react"
 import { twJoin, twMerge } from "tailwind-merge"
 


### PR DESCRIPTION

## Description

Adds missing `"use client"` directives to components that use client-side React features in the Next.js App Router environment. These directives were being caught by the new CI checks.

## Changes

- ✅ Added `"use client"` to `line-chart-custom-colors-demo.tsx` (uses `useMemo`, `useIsMobile`)
- ✅ Added `"use client"` to `line-chart-stacked-demo.tsx` (uses `useMemo`, `useIsMobile`)
- ✅ Added `"use client"` to `leaderboard.tsx` (react-aria-components interaction)
- ✅ Added `"use client"` to `scroll-area.tsx` (uses `useRef`, `useLayoutEffect`)

## Motivation

These components use React hooks (`useRef`, `useLayoutEffect`, `useMemo`) and external component libraries that require client-side execution. The `"use client"` directive explicitly marks them as client components, preventing potential hydration mismatches and following Next.js 13+ App Router best practices.

**Note:** This aligns with the project's `bun run cuc` check which validates "use client" directives across the codebase.

## Type of Change

- [x] Bug fix (fixes missing directives causing potential SSR issues)
- [x] Refactoring / Code quality improvement

## How Has This Been Tested?

- [x] Manual testing - verified components render correctly with directive
- [x] Checked for hydration errors
- [x] Ran `bun run cuc` - all components now pass validation
- [x] Existing tests passed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have run `bun run build` and it passed without errors
- [x] I have run `bun run lint` and `bun run cuc` and they passed
- [x] All components verified to use client-side features