### PR TITLE
add: FUNDING.yml to support funding model platforms

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: [irsyadadl]
+ko_fi: irsyadadl 


### PR DESCRIPTION

## Description

Adds GitHub Sponsors support to enable sponsorship buttons and integration for the project.

## Changes

- ✅ **Added** `.github/FUNDING.yml` - Enables GitHub Sponsors integration

## Motivation

The README mentions sponsorship support ("I will sponsor now"), but GitHub Sponsors wasn't configured. This enables the sponsorship functionality mentioned in the docs.

## Type of Change

- [x] New feature (GitHub Sponsors)
- [x] Repository enhancement

## How Has This Been Tested?

- [x] FUNDING.yml follows GitHub's format requirements
- [x] Uses correct GitHub username from package.json author field

## Checklist

- [x] FUNDING.yml uses correct GitHub username
- [x] Follows GitHub Sponsors file format
- [x] I have run `npm run build` and it passed
- [x] I have run `npm run lint` and `npm run cuc` and they passed