### PR TITLE
fix: enhance Inertia.js Link integration with improved type support

### DIFF
--- a/src/content/docs/getting-started/client-side-routing.mdx
+++ b/src/content/docs/getting-started/client-side-routing.mdx
@@ -36,14 +36,14 @@ The same pattern can also be used with `MenuItem`.
 When using Laravel with Inertia.js, you can render the `Link` component as an Inertia `Link`.
 
 ```tsx
+import { Link as InertiaLink, type InertiaLinkProps } from "@inertiajs/react"
 import {
   Link as LinkPrimitive,
   type LinkProps as LinkPrimitiveProps,
 } from "react-aria-components/Link"
-import { type InertiaLinkProps, Link as InertiaLink } from "@inertiajs/react"
 import { cx } from "@/lib/primitive"
 
-export interface LinkProps extends LinkPrimitiveProps {
+export interface LinkProps extends LinkPrimitiveProps, Omit<InertiaLinkProps, keyof LinkPrimitiveProps> {
   ref?: React.RefObject<HTMLAnchorElement>
 }
 
@@ -60,14 +60,14 @@ export function Link({ className, ref, ...props }: LinkProps) {
         ],
         className,
       )}
-      {...props}
       render={(domProps) =>
         "href" in domProps ? (
-          <InertiaLink {...(domProps as InertiaLinkProps)} />
+          <InertiaLink {...(props as InertiaLinkProps)} {...(domProps as InertiaLinkProps)} />
         ) : (
           <span {...domProps} />
         )
       }
+      {...(props as LinkPrimitiveProps)}
     />
   )
 }


### PR DESCRIPTION
**Description:**
This PR improves the integration of the `Link` component with Inertia.js by addressing type deficiencies and props passing logic.

**Key Changes:**
- **Improved Type Safety:** Added `Omit<InertiaLinkProps, keyof LinkPrimitiveProps>` to the `LinkProps` interface. This allows the `Link` component to accept and properly type all standard Inertia.js link attributes (e.g., `method`, `preserveScroll`, `only`) while avoiding conflicts with React Aria props.
- **Props Resolution:** Updated the `render` function to spread both the original component `props` and the `domProps` provided by React Aria. This ensures that Inertia-specific behaviors are correctly applied to the underlying `InertiaLink` component.

**Why this is needed:**
Previously, the `Link` component did not expose the full API of Inertia's `Link`. If a user attempted to use props like `method="post"` or `as="button"`, TypeScript would complain, and the props were not being effectively passed through to the underlying Inertia component.